### PR TITLE
Update to latest protobuf version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -705,16 +705,16 @@
         },
         {
             "name": "google/protobuf",
-            "version": "v3.6.1.3",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/protocolbuffers/protobuf.git",
-                "reference": "66dc42d891a4fc8e9190c524fd67961688a37bbe"
+                "url": "https://github.com/protocolbuffers/protobuf-php.git",
+                "reference": "0657d28864692480c3d8506ba4fc90e8813deae5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf/zipball/66dc42d891a4fc8e9190c524fd67961688a37bbe",
-                "reference": "66dc42d891a4fc8e9190c524fd67961688a37bbe",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/0657d28864692480c3d8506ba4fc90e8813deae5",
+                "reference": "0657d28864692480c3d8506ba4fc90e8813deae5",
                 "shasum": ""
             },
             "require": {
@@ -729,8 +729,8 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Google\\Protobuf\\": "php/src/Google/Protobuf",
-                    "GPBMetadata\\Google\\Protobuf\\": "php/src/GPBMetadata/Google/Protobuf"
+                    "Google\\Protobuf\\": "src/Google/Protobuf",
+                    "GPBMetadata\\Google\\Protobuf\\": "src/GPBMetadata/Google/Protobuf"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -742,7 +742,7 @@
             "keywords": [
                 "proto"
             ],
-            "time": "2018-12-08T01:32:11+00:00"
+            "time": "2019-03-26T18:06:41+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",


### PR DESCRIPTION
Update to the latest protobuf version. Updates from 3.6.1 -> 3.7.1

There appears to be an issue with the autoloading settings currently in the composer.lock file.  We are seeing `PHP Fatal error: Class 'Google\Protobuf\Internal\Message' not found` after performing a composer update in a program that has twirfony as a dependency.

This is happening because of the autoload settings for protobuf in this repo, which specify:

```json
            "autoload": {
                "psr-4": {
                    "Google\\Protobuf\\": "php/src/Google/Protobuf",
                    "GPBMetadata\\Google\\Protobuf\\": "php/src/GPBMetadata/Google/Protobuf"
                }
            },
```

Updating fixes up this autoloading issue. This should in turn fix the downstream autoloading problems described above.
